### PR TITLE
cli: Use timestamp as timeout by default (GoN)

### DIFF
--- a/types/packet.go
+++ b/types/packet.go
@@ -12,7 +12,7 @@ var (
 	// DefaultRelativePacketTimeoutHeight is the default packet timeout height (in blocks) relative
 	// to the current block height of the counterparty chain provided by the client state. The
 	// timeout is disabled when set to 0.
-	DefaultRelativePacketTimeoutHeight = "0-1000"
+	DefaultRelativePacketTimeoutHeight = "0-0"
 
 	// DefaultRelativePacketTimeoutTimestamp is the default packet timeout timestamp (in nanoseconds)
 	// relative to the current block timestamp of the counterparty chain provided by the client


### PR DESCRIPTION
this would avoid errors (IBC Timeouts) when the ClientState is not updated frequently. 

Ref: https://github.com/game-of-nfts/gon-evidence/issues/235